### PR TITLE
Removes liblognorm V1 rulebase support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,6 +573,7 @@
             <exclude>src/main/c/Makefile.am</exclude>
             <!-- test resources -->
             <exclude>src/test/resources/sample.rulebase</exclude>
+            <exclude>src/test/resources/sampleV1.rulebase</exclude>
             <exclude>src/test/resources/sample2.rulebase</exclude>
             <exclude>src/test/resources/sample3.rulebase</exclude>
           </excludes>

--- a/src/main/c/JavaLognorm.c
+++ b/src/main/c/JavaLognorm.c
@@ -155,3 +155,8 @@ int setDebugCB(ln_ctx *ctx, const DebugCallback debugCallback) {
 int setErrMsgCB(ln_ctx *ctx, const ErrorCallback errorCallback) {
     return ln_setErrMsgCB(*ctx, errorCallback, NULL);
 }
+
+int rulebaseVersion(ln_ctx *context) {
+    ln_ctx ctx = *context;
+    return ctx->version;
+}

--- a/src/main/c/JavaLognorm.c
+++ b/src/main/c/JavaLognorm.c
@@ -49,7 +49,6 @@
 #include <lognorm.h>
 
 typedef struct OptionsStruct_TAG {
-    int CTXOPT_ALLOW_REGEX;
     int CTXOPT_ADD_EXEC_PATH;
     int CTXOPT_ADD_ORIGINALMSG;
     int CTXOPT_ADD_RULE;
@@ -89,9 +88,6 @@ int exitCtx(ln_ctx *context) {
 
 void setCtxOpts(ln_ctx *ctx, OptionsStruct *opts) {
     unsigned ctxOpts = 0;
-    if (opts->CTXOPT_ALLOW_REGEX != 0) {
-        ctxOpts |= LN_CTXOPT_ALLOW_REGEX;
-        }
     if (opts->CTXOPT_ADD_EXEC_PATH != 0) {
         ctxOpts |= LN_CTXOPT_ADD_EXEC_PATH;
         }

--- a/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
+++ b/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
@@ -140,4 +140,7 @@ public interface LibJavaLognorm extends Library {
 
     // Set a callback for error logging
     public abstract int setErrMsgCB(Pointer ctx, ErrorCallback func);
+
+    // Return rulebase version currently used by the context.
+    public abstract int rulebaseVersion(Pointer ctx);
 }

--- a/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
+++ b/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
@@ -86,15 +86,10 @@ public interface LibJavaLognorm extends Library {
 
     // JNA requires the @FieldOrder annotation so it can properly serialize data into a memory buffer before using it as an argument to the target method.
     @FieldOrder({
-            "CTXOPT_ALLOW_REGEX",
-            "CTXOPT_ADD_EXEC_PATH",
-            "CTXOPT_ADD_ORIGINALMSG",
-            "CTXOPT_ADD_RULE",
-            "CTXOPT_ADD_RULE_LOCATION"
+            "CTXOPT_ADD_EXEC_PATH", "CTXOPT_ADD_ORIGINALMSG", "CTXOPT_ADD_RULE", "CTXOPT_ADD_RULE_LOCATION"
     })
     public static class OptionsStruct extends Structure {
 
-        public boolean CTXOPT_ALLOW_REGEX = false;
         public boolean CTXOPT_ADD_EXEC_PATH = false;
         public boolean CTXOPT_ADD_ORIGINALMSG = false;
         public boolean CTXOPT_ADD_RULE = false;

--- a/src/main/java/com/teragrep/rsm_01/LognormFactory.java
+++ b/src/main/java/com/teragrep/rsm_01/LognormFactory.java
@@ -144,7 +144,7 @@ public final class LognormFactory {
         }
         catch (IOException e) {
             LOGGER.error("Error reading rulebase file");
-            throw new IllegalArgumentException("Error reading rulebase file: ", e);
+            throw new IllegalArgumentException("Error reading rulebase file", e);
         }
     }
 

--- a/src/main/java/com/teragrep/rsm_01/LognormFactory.java
+++ b/src/main/java/com/teragrep/rsm_01/LognormFactory.java
@@ -119,20 +119,20 @@ public final class LognormFactory {
         }
     }
 
-    private void liblognormLoadSamples(Pointer ctx, String rulebase) {
-        int i = LibJavaLognorm.jnaInstance.loadSamples(ctx, rulebase);
+    private void liblognormLoadSamples(Pointer ctx, String rulebaseFile) {
+        // Check for version=2 line from rulebase.
+        checkRulebaseVersion(rulebaseFile);
+        int i = LibJavaLognorm.jnaInstance.loadSamples(ctx, rulebaseFile);
         if (i != 0) {
             LOGGER.error("ln_loadSamples() returned error code <{}>", i);
             throw new IllegalArgumentException("ln_loadSamples() returned " + i + " instead of 0");
         }
-        // Check for version=2 line from rulebase.
-        checkRulebaseVersion(rulebase);
     }
 
-    private void checkRulebaseVersion(String rulebase) {
+    private void checkRulebaseVersion(String rulebaseFile) {
         BufferedReader reader;
         try {
-            reader = new BufferedReader(new FileReader(rulebase));
+            reader = new BufferedReader(new FileReader(rulebaseFile));
             String line = reader.readLine();
             if (Objects.equals(line, "version=2")) {
                 reader.close();

--- a/src/main/java/com/teragrep/rsm_01/LognormFactory.java
+++ b/src/main/java/com/teragrep/rsm_01/LognormFactory.java
@@ -50,6 +50,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Objects;
 
 public final class LognormFactory {
 
@@ -120,6 +124,27 @@ public final class LognormFactory {
         if (i != 0) {
             LOGGER.error("ln_loadSamples() returned error code <{}>", i);
             throw new IllegalArgumentException("ln_loadSamples() returned " + i + " instead of 0");
+        }
+        // Check for version=2 line from rulebase.
+        checkRulebaseVersion(rulebase);
+    }
+
+    private void checkRulebaseVersion(String rulebase) {
+        BufferedReader reader;
+        try {
+            reader = new BufferedReader(new FileReader(rulebase));
+            String line = reader.readLine();
+            if (Objects.equals(line, "version=2")) {
+                reader.close();
+            }
+            else {
+                reader.close();
+                throw new IllegalArgumentException("Loaded rulebase is not using version 2");
+            }
+        }
+        catch (IOException e) {
+            LOGGER.error("Error reading rulebase file");
+            throw new IllegalArgumentException("Error reading rulebase file: ", e);
         }
     }
 

--- a/src/main/java/com/teragrep/rsm_01/LognormFactory.java
+++ b/src/main/java/com/teragrep/rsm_01/LognormFactory.java
@@ -50,10 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Objects;
 
 public final class LognormFactory {
 
@@ -120,31 +116,14 @@ public final class LognormFactory {
     }
 
     private void liblognormLoadSamples(Pointer ctx, String rulebaseFile) {
-        // Check for version=2 line from rulebase.
-        checkRulebaseVersion(rulebaseFile);
         int i = LibJavaLognorm.jnaInstance.loadSamples(ctx, rulebaseFile);
         if (i != 0) {
             LOGGER.error("ln_loadSamples() returned error code <{}>", i);
             throw new IllegalArgumentException("ln_loadSamples() returned " + i + " instead of 0");
         }
-    }
-
-    private void checkRulebaseVersion(String rulebaseFile) {
-        BufferedReader reader;
-        try {
-            reader = new BufferedReader(new FileReader(rulebaseFile));
-            String line = reader.readLine();
-            if (Objects.equals(line, "version=2")) {
-                reader.close();
-            }
-            else {
-                reader.close();
-                throw new IllegalArgumentException("Loaded rulebase is not using version 2");
-            }
-        }
-        catch (IOException e) {
-            LOGGER.error("Error reading rulebase file");
-            throw new IllegalArgumentException("Error reading rulebase file", e);
+        // Check rulebase version.
+        if (LibJavaLognorm.jnaInstance.rulebaseVersion(ctx) != 2) {
+            throw new IllegalArgumentException("Loaded rulebase is not using version 2");
         }
     }
 

--- a/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
+++ b/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
@@ -119,7 +119,7 @@ public class LognormFactoryTest {
             LognormFactory lognormFactory = new LognormFactory(sampleFile);
             IllegalArgumentException e = Assertions
                     .assertThrows(IllegalArgumentException.class, () -> lognormFactory.lognorm());
-            Assertions.assertEquals("Error reading rulebase file", e.getMessage());
+            Assertions.assertEquals("ln_loadSamples() returned 1 instead of 0", e.getMessage());
         });
     }
 

--- a/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
+++ b/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
@@ -124,6 +124,19 @@ public class LognormFactoryTest {
     }
 
     @Test
+    public void loadSamplesV1ExceptionTest() {
+        assertDoesNotThrow(() -> {
+            String samplesPath = "src/test/resources/sampleV1.rulebase"; // rulebase using V1 format.
+            File sampleFile = new File(samplesPath);
+            Assertions.assertTrue(sampleFile.exists());
+            LognormFactory lognormFactory = new LognormFactory(sampleFile);
+            IllegalArgumentException e = Assertions
+                    .assertThrows(IllegalArgumentException.class, () -> lognormFactory.lognorm());
+            Assertions.assertEquals("Loaded rulebase is not using version 2", e.getMessage());
+        });
+    }
+
+    @Test
     public void loadSamplesFromStringTest() {
         assertDoesNotThrow(() -> {
             LibJavaLognorm.OptionsStruct opts = new LibJavaLognorm.OptionsStruct();

--- a/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
+++ b/src/test/java/com/teragrep/rsm_01/LognormFactoryTest.java
@@ -119,7 +119,7 @@ public class LognormFactoryTest {
             LognormFactory lognormFactory = new LognormFactory(sampleFile);
             IllegalArgumentException e = Assertions
                     .assertThrows(IllegalArgumentException.class, () -> lognormFactory.lognorm());
-            Assertions.assertEquals("ln_loadSamples() returned 1 instead of 0", e.getMessage());
+            Assertions.assertEquals("Error reading rulebase file", e.getMessage());
         });
     }
 

--- a/src/test/resources/sample.rulebase
+++ b/src/test/resources/sample.rulebase
@@ -1,2 +1,3 @@
+version=2
 rule=:%all:rest%
 rule=tag1:Quantity: %N:number%

--- a/src/test/resources/sampleV1.rulebase
+++ b/src/test/resources/sampleV1.rulebase
@@ -1,0 +1,2 @@
+rule=:%all:rest%
+rule=tag1:Quantity: %N:number%


### PR DESCRIPTION
Includes:
- Removal of liblognorm V1 rulebase support from the project to fix issue #23 
- Tests for the changes.

In other words only V2 rulebase format is supported, usage of V1 rulebase will throw an exception.