### PR TITLE
Removes access to LN_CTXOPT_ADD_EXEC_PATH liblognorm configuration option

### DIFF
--- a/src/main/c/JavaLognorm.c
+++ b/src/main/c/JavaLognorm.c
@@ -49,7 +49,6 @@
 #include <lognorm.h>
 
 typedef struct OptionsStruct_TAG {
-    int CTXOPT_ADD_EXEC_PATH;
     int CTXOPT_ADD_ORIGINALMSG;
     int CTXOPT_ADD_RULE;
     int CTXOPT_ADD_RULE_LOCATION;
@@ -88,9 +87,6 @@ int exitCtx(ln_ctx *context) {
 
 void setCtxOpts(ln_ctx *ctx, OptionsStruct *opts) {
     unsigned ctxOpts = 0;
-    if (opts->CTXOPT_ADD_EXEC_PATH != 0) {
-        ctxOpts |= LN_CTXOPT_ADD_EXEC_PATH;
-        }
     if (opts->CTXOPT_ADD_ORIGINALMSG != 0) {
         ctxOpts |= LN_CTXOPT_ADD_ORIGINALMSG;
         }

--- a/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
+++ b/src/main/java/com/teragrep/rsm_01/LibJavaLognorm.java
@@ -86,11 +86,10 @@ public interface LibJavaLognorm extends Library {
 
     // JNA requires the @FieldOrder annotation so it can properly serialize data into a memory buffer before using it as an argument to the target method.
     @FieldOrder({
-            "CTXOPT_ADD_EXEC_PATH", "CTXOPT_ADD_ORIGINALMSG", "CTXOPT_ADD_RULE", "CTXOPT_ADD_RULE_LOCATION"
+            "CTXOPT_ADD_ORIGINALMSG", "CTXOPT_ADD_RULE", "CTXOPT_ADD_RULE_LOCATION"
     })
     public static class OptionsStruct extends Structure {
 
-        public boolean CTXOPT_ADD_EXEC_PATH = false;
         public boolean CTXOPT_ADD_ORIGINALMSG = false;
         public boolean CTXOPT_ADD_RULE = false;
         public boolean CTXOPT_ADD_RULE_LOCATION = false;


### PR DESCRIPTION
Includes:
- Removes access to the liblognorm `LN_CTXOPT_ADD_EXEC_PATH` option from java, solving issue #29.

Extensive testing showed that the `LN_CTXOPT_ADD_EXEC_PATH` configuration option included in the liblognorm library did not produce any of the expected effects on the normalization result. Thus access to the option is safe to remove as it is no-op.